### PR TITLE
docs(reuse): 8 extended artifact categories + pe-bootstrap --categories flag

### DIFF
--- a/profiles/project/pack-engineering/skills/pe-bootstrap.md
+++ b/profiles/project/pack-engineering/skills/pe-bootstrap.md
@@ -22,6 +22,16 @@ Triggers (from `ce-task.md` PACK_BOOTSTRAP archetype or `/stx-pe:bootstrap`) :
 - `--pack-name <name>` (optional ; orchestrator proposes a default).
 - `--target-path <path>` (optional ; defaults to `../<pack-name>/`).
 - `--active-ds <ref>` (optional ; defaults to `default` — orchestrator scaffolds a minimal DS).
+- `--categories <list>` (optional, manifest 0.2+) : comma-separated list of
+  extended artifact categories to scaffold under `[pack.data]` in addition
+  to the default Python artifacts. Choices:
+  `palette,ai_prompt,archetype,guideline,skill,agent,asset,integration`.
+  Example: `--categories palette,ai_prompt,skill`. When provided, the
+  orchestrator scaffolds the matching subdirectories and pre-populates
+  the manifest `[pack.data]` section. Each requested category is enumerated
+  by the pack-miner (Step 1 DISCOVERY) to look for data-first idioms in
+  the source projects (palette JSON files, AI prompt text files,
+  archetype-shaped markdown, etc.).
 
 ## Workflow
 
@@ -70,6 +80,28 @@ The QCM phrasing in Step 0 is adapted :
 - `--min-projects 2`.
 - `--dedup-against-packs true` (pack-miner skips clusters already covered
   by `streamtex-pack-design` if installed).
+- `--categories` empty (= manifest 0.1 only ; no `[pack.data]` section
+  is written, the pack stays Python-only by default — the most common
+  bootstrap scenario).
 - DS scaffolded with 5 minimal bundles : `colors`, `titles`, `body`,
   `callouts`, `card_grid` (enough for the most common components).
 - Initial kit `recommended` containing the top-5 components by usage count.
+
+## Manifest 0.2 categories — when to enable each
+
+If the source projects contain any of the following idioms, enable the
+matching category via `--categories`:
+
+| Source idiom found in the N projects | Add category |
+|---|---|
+| A JSON palette file shared across projects | `palette` |
+| AI image generation prompts (prefix + suffixes) | `ai_prompt` |
+| Reusable visual scene descriptions in markdown | `archetype` |
+| Project-side `design-guideline.md` files | `guideline` |
+| `.claude/custom/skills/*.md` files repeated across projects | `skill` |
+| Trainer / domain-specific agents in `.claude/custom/agents/` | `agent` |
+| Logo / font files copy-pasted across projects | `asset` |
+| A `custom/` recipe pointing at an external system | `integration` |
+
+The pack-miner reports candidates per category in its DISCOVERY output
+so the orchestrator can prompt the user to enable / disable each.

--- a/shared/skills/reuse-architecture.md
+++ b/shared/skills/reuse-architecture.md
@@ -170,10 +170,102 @@ INTEGRATE promotion (§8.3) has four destinations (Q12):
    push + `gh pr create`.
 4. **PyPI pack** → refused (PR001).
 
+## Extended artifacts (manifest 0.2+) — beyond Python
+
+The original pack contract (manifest format 0.1) ships **only Python**
+artifacts: components, design systems, kits, CLI templates, project
+blueprints. Manifest format **0.2** is **additive** — it unlocks an
+optional `[pack.data]` section that lets a pack also ship eight data-first
+and documentation categories.
+
+### The 8 extended categories
+
+| Category | Filesystem convention | Canonical format | Used for |
+|---|---|---|---|
+| **palette** | `<pack>/palettes/<name>.json` | JSON | Color tokens + semantic dimensions ; Python view generated via `streamtex.core.artifacts.palette.load_palette()` |
+| **ai_prompt** | `<pack>/ai_prompts/<name>/{prefix,suffix-*}.txt` | TXT | Reusable AI image-generation prompts (PREFIX + scene + SUFFIX-orientation) |
+| **archetype** | `<pack>/archetypes/<name>.md` | Markdown + YAML frontmatter | Reusable visual scene compositions (bridge, horizon, balance, …) |
+| **guideline** | `<pack>/guidelines/<name>.md` | Markdown + YAML frontmatter | Opposable rules (R1-R13) ; agents and humans must respect |
+| **skill** | `<pack>/skills/<name>.md` | Markdown + Claude Code frontmatter | Pack-scoped Claude Code skills, installed to `.claude/custom/skills/<pack>__<name>.md` |
+| **agent** | `<pack>/agents/<name>.md` | Markdown + Claude Code frontmatter | Pack-scoped Claude Code agents |
+| **asset** | `<pack>/assets/_manifest.toml` + binaries | TOML + bytes | Logos, fonts, images with license tracking |
+| **integration** | `<pack>/integrations/<framework>/` | Open contract | Recipe per third-party framework (streamtex, figma, midjourney, …) |
+
+### Declaring extended artifacts
+
+In `_pack_manifest.toml`:
+
+```toml
+[manifest]
+format = "0.2"
+
+[pack.data]
+palettes = ["main"]
+ai_prompts = ["scene_generation"]
+archetypes = ["bridge", "horizon", "balance"]
+guidelines = ["graphic-line"]
+skills = ["author-helper"]
+agents = ["design-reviewer"]
+assets = ["assets"]            # bundle name (matches dir name)
+integrations = ["streamtex", "figma"]
+```
+
+The list must match the on-disk slugs. An unlisted file on disk is **not**
+enumerated by `discover_artifacts`. Format 0.1 packs (no `[pack.data]`)
+still work unchanged.
+
+### Generic CLI
+
+```bash
+stx artifact list                            # all categories, all packs
+stx artifact list --kind palette             # filter by category
+stx artifact list --pack streamtex-pack-gse  # filter by pack
+stx artifact show <name> --kind <k>          # formatted view
+stx artifact validate                        # validate every artifact
+stx artifact install <name> --kind skill     # install into .claude/custom/
+```
+
+### Lifecycle hooks
+
+Skills and agents are the only categories with a project-side install
+step: they're copied to `.claude/custom/skills/` (or `agents/`) so Claude
+Code discovers them. Convention:
+
+- Filename in the project: `<pack_slug>__<name>.md` (e.g.
+  `gse__gse-author.md`). Avoids cross-pack collisions.
+- Confirmation prompt by default at `stx artifact install` ; `--yes` to
+  skip.
+
+The other categories (palette, ai_prompt, archetype, guideline, asset,
+integration) are consumed **lazily at runtime** from the installed pack —
+no copy step.
+
+### When to use which category
+
+| You want to ship … | Category |
+|---|---|
+| Color tokens for components AND for outside tools (Figma, Midjourney) | palette |
+| A reusable prompt template for AI image generation | ai_prompt |
+| A reusable visual composition pattern (with "use when / forbidden" guardrails) | archetype |
+| Opposable spec rules ("R1: one idea per slide") | guideline |
+| Domain expertise Claude Code should pick up automatically | skill |
+| A multi-step agent workflow Claude Code should invoke | agent |
+| Logos, fonts, images with license tracking | asset |
+| Recipe for using the pack from another tool (Figma, Midjourney, …) | integration |
+
+`streamtex-pack-gse v2.0.0` ships all 8 categories — see it as the
+reference example of a 0.2-format pack.
+
 ## Where to learn more
 
 - `streamtex/documentation/maintenance/reuse-architecture/PLAN.md` —
   authoritative spec (3888 lines).
-- `streamtex-pack-design` (in `streamtex-packs` monorepo) — the official reference pack.
+- `streamtex/documentation/maintenance/design-packs/RFC-extended-artifacts.md`
+  — the RFC behind manifest 0.2 + the 8 extended categories (local to
+  workspace, not in the public repo).
+- `streamtex-pack-design` (in `streamtex-packs` monorepo) — the official
+  reference pack for the Python artifacts (manifest 0.1).
+- `streamtex-pack-gse v2.0.0` — the reference example for manifest 0.2
+  extended artifacts.
 - CLI: `stx pack --help`, `stx component --help`, `stx ds --help`,
-  `stx kit --help`, `stx validate --help`.
+  `stx kit --help`, `stx artifact --help`, `stx validate --help`.


### PR DESCRIPTION
## Summary

Documents and surfaces the manifest-0.2 extended artifact system at the
Claude Code level:

### `shared/skills/reuse-architecture.md`
New section **"Extended artifacts (manifest 0.2+) — beyond Python"** with:
- Comparison table of the 8 categories (palette, ai_prompt, archetype,
  guideline, skill, agent, asset, integration).
- Declaration example for `[pack.data]`.
- Generic CLI surface (`stx artifact list|show|validate|install`).
- Lifecycle hook details for skills/agents (`<pack_slug>__<name>.md`
  convention, confirmation prompt by default).
- Decision matrix "when to use which category".

### `profiles/project/pack-engineering/skills/pe-bootstrap.md`
Adds:
- New `--categories <list>` input documented in the Inputs section.
- "Manifest 0.2 categories — when to enable each" table mapping
  source-project idioms to the matching category (used by pack-miner
  in DISCOVERY).
- New default behavior: empty `--categories` keeps pack as 0.1-style
  (Python-only).

## Test plan
- [ ] After this PR merges, `stx claude install project <project>` picks
      up the updated skills automatically.
- [ ] Reading `reuse-architecture` skill in Claude Code now mentions the
      8 categories.

## Sister PRs
- `streamtex` #29 — generic artifact engine
- `streamtex-packs` — pack-gse v2.0 reference implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)